### PR TITLE
Scry from %grouper to set invite links checkbox

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -65,5 +65,12 @@
 ++  on-save   !>(state)
 ++  on-load   |=(old=vase `this(state !<(_state old)))
 ++  on-arvo   on-arvo:def
-++  on-peek   on-peek:def
+++  on-peek
+  |=  =path
+  ^-  (unit (unit cage))
+  ?+  path  [~ ~]
+      [%x %enabled @ ~]
+    ``json+!>([%b (~(has in enabled-groups) i.t.t.path)])
+  ==
+::
 --

--- a/desk/mar/reel/bite.hoon
+++ b/desk/mar/reel/bite.hoon
@@ -1,9 +1,9 @@
-/-  lure
-|_  =bait:lure
+/-  reel
+|_  =bite:reel
 ++  grad  %noun
 ++  grab
   |%
-  ++  noun  bait:lure
+  ++  noun  bite:reel
   --
 ++  grow
   |%

--- a/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
+++ b/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
@@ -19,6 +19,7 @@ import {
   lurePokeDescription,
   lureEnableGroup,
   lureDisableGroup,
+  useLureEnabled,
 } from '@/state/lure/lure';
 import GroupInfoFields from '../GroupInfoFields';
 import PrivacySelector from '../PrivacySelector';
@@ -46,7 +47,7 @@ export default function GroupInfoEditor({ title }: ViewProps) {
   const lureBait = useLureBait();
   const name = useGroupName();
   const lureToken = name;
-  const [lureEnabled, setLureEnabled] = useState(false);
+  const [lureEnabled, setLureEnabled] = useLureEnabled(name);
   const lureURL = `${lureBait}${window.our}/${lureToken}`;
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy');
   const [lureDescription, setLureDescription] = useState(

--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -15,6 +15,21 @@ export function useLureBait() {
   return lureBait;
 }
 
+export function useLureEnabled(name: string): [boolean, (b: boolean) => void] {
+  const [lureEnabled, setLureEnabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    api
+      .scry<boolean>({
+        app: 'grouper',
+        path: `/enabled/${name}`,
+      })
+      .then((result) => setLureEnabled(result));
+  });
+
+  return [lureEnabled, setLureEnabled];
+}
+
 export async function lurePokeDescription(token: string, description: string) {
   await api.poke({
     app: 'reel',


### PR DESCRIPTION
Before, the "invite links enabled" checkbox always defaulted to unchecked, even when they were enabled for the group. Now the frontend scries from %grouper to see if it should be checked.