### PR TITLE
build: add automatic deployment workflow

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,17 @@
+name: Push to develop
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/**.yml'
+      - '.github/workflows/scripts/**.sh'
+      - 'desk/**'
+
+jobs:
+  urbit:
+    uses: ./.github/workflows/shared.yml
+    with:
+      ship: 'samnec-dozzod-marzod'
+    secrets: inherit

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,43 @@
+on:
+  workflow_call:
+    inputs:
+      ship:
+        description: 'Name of ship/GCP instance'
+        type: string
+        default: false
+        required: true
+    secrets:
+      GCP_CREDENTIALS:
+        required: true
+      GCP_PROJECT:
+        required: true
+      GCP_USER:
+        required: true
+      GCP_ZONE:
+        required: true
+      TAILSCALE_AUTHKEY:
+        required: true
+
+jobs:
+  upload:
+    runs-on: 'ubuntu-latest'
+    name: 'Sync files to ship'
+
+    steps:
+      - uses: 'actions/checkout@v3'
+
+      - id: 'tailscale'
+        name: 'Login to Tailscale'
+        uses: 'tailscale/github-action@v1'
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
+      - id: 'gcp-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: 'SSH and sync'
+        run: |
+          gcloud compute ssh --internal-ip --project ${{ secrets.GCP_PROJECT }} --zone ${{ secrets.GCP_ZONE }} --command './commands/sync.sh' ${{ secrets.GCP_USER }}@${{ inputs.ship }}


### PR DESCRIPTION
`v0.1` of automated deployment. Runs successfully, as seen [here](https://github.com/tloncorp/lure/actions/runs/4015485804/jobs/6897267380).

Notes:
- The Tailscale auth key expires every 90 days; there is no way around this, currently
- During testing, GitHub Actions didn't like me trying to split up the command over multiple lines with `\`, so it's all jammed into one line
- `gcloud compute ssh` doesn't accept script file commands
- On the other hand, the [ssh-compute action](https://github.com/google-github-actions/ssh-compute) *does* support using script files to pass commands, but it always injects a `--tunnel-through-iap` flag into the command which screws up our build
- For that reason, I just put the script onto the machine itself. Script contents (taken almost entirely from Janeway):
```
#!/bin/bash

set -e

SOURCE_REPO=`mktemp -d -t`
URBIT_REPO=`mktemp -d -t`

git clone --depth=1 --branch develop https://github.com/tloncorp/lure.git $SOURCE_REPO
git clone --depth=1 --branch master https://github.com/urbit/urbit.git $URBIT_REPO

curl -s --data '{"source":{"dojo":"+hood/mount %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null
rsync -avL --delete "$SOURCE_REPO/desk/" "samnec-dozzod-marzod/lure"
rsync -avL "$URBIT_REPO/pkg/base-dev/" "samnec-dozzod-marzod/lure"
curl -s --data '{"source":{"dojo":"+hood/commit %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null
curl -s --data '{"source":{"dojo":"+hood/unmount %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null

rm -rf $SOURCE_REPO
rm -rf $URBIT_REPO

echo SUCCESS
```

I'll keep playing around to see if I can find something more graceful.