### PR TITLE
build: add automatic prod deployment workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,17 @@
+name: Push to master
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**.yml'
+      - '.github/workflows/scripts/**.sh'
+      - 'desk/**'
+
+jobs:
+  urbit:
+    uses: ./.github/workflows/shared.yml
+    with:
+      ship: 'litnec-dozzod-marzod'
+    secrets: inherit


### PR DESCRIPTION
Fixes: #15 

Same as #12, but for `master`. Script on `litnec` updated accordingly:
```
#!/bin/bash

set -e

LURE_PATH="litnec-dozzod-marzod/lure"

SOURCE_REPO=`mktemp -d -t`
URBIT_REPO=`mktemp -d -t`
LANDSCAPE_REPO=`mktemp -d -t`

git clone --depth=1 --branch master https://github.com/tloncorp/lure.git $SOURCE_REPO
git clone --depth=1 --branch master https://github.com/urbit/urbit.git $URBIT_REPO
git clone --depth=1 --branch master https://github.com/tloncorp/landscape.git $LANDSCAPE_REPO

curl -s --data '{"source":{"dojo":"+hood/mount %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null

rsync -avL --delete "$SOURCE_REPO/desk/" $LURE_PATH
rsync -avL "$URBIT_REPO/pkg/base-dev/" $LURE_PATH
rsync -avL "$LANDSCAPE_REPO/desk-dev/lib/docket.hoon" "$LURE_PATH/lib"
rsync -avL "$LANDSCAPE_REPO/desk-dev/sur/docket.hoon" "$LURE_PATH/sur"
rsync -avL "$LANDSCAPE_REPO/desk-dev/mar/docket-0.hoon" "$LURE_PATH/mar"

curl -s --data '{"source":{"dojo":"+hood/commit %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null
curl -s --data '{"source":{"dojo":"+hood/unmount %lure"},"sink":{"app":"hood"}}' http://localhost:12321 > /dev/null

rm -rf $SOURCE_REPO
rm -rf $URBIT_REPO
rm -rf $LANDSCAPE_REPO

echo SUCCESS
```