### PR TITLE
build: stop clobbering glob with CD

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -21,8 +21,6 @@ git clone --depth=1 --branch master https://github.com/tloncorp/landscape.git $L
 
 curl -s --data '"'"'{"source":{"dojo":"+hood/mount %lure"},"sink":{"app":"hood"}}'"'"' http://localhost:12321 > /dev/null
 
-rsync -avL "$LURE_PATH/desk.docket-0" "$SOURCE_REPO/desk/"
-
 rsync -avL --delete "$SOURCE_REPO/desk/" $LURE_PATH
 rsync -avL "$URBIT_REPO/pkg/base-dev/" $LURE_PATH
 rsync -avL "$LANDSCAPE_REPO/desk-dev/lib/docket.hoon" "$LURE_PATH/lib"
@@ -46,4 +44,4 @@ gcloud compute ssh \
   --command "$(sed '/^$/d' $CMD_FILE | sed ':a;N;s/\n/ && /;$!ba')" \
   $GCP_USER@$SHIP
 
-echo "%lure deploy performed for $SHIP"
+echo "%lure desk deployed to $SHIP"

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -6,6 +6,7 @@ set -o pipefail
 SHIP=$1
 BRANCH=$2
 
+# XX: Do we need '--ignore-existing' opts for dev rsyncs?
 CMD_FILE=`mktemp --tmpdir "lure.XXXXXX"`
 CMDS='
 LURE_PATH="'$SHIP'/lure"
@@ -20,6 +21,8 @@ git clone --depth=1 --branch master https://github.com/tloncorp/landscape.git $L
 
 curl -s --data '"'"'{"source":{"dojo":"+hood/mount %lure"},"sink":{"app":"hood"}}'"'"' http://localhost:12321 > /dev/null
 
+rsync -avL "$LURE_PATH/desk.docket-0" "$SOURCE_REPO/desk/"
+
 rsync -avL --delete "$SOURCE_REPO/desk/" $LURE_PATH
 rsync -avL "$URBIT_REPO/pkg/base-dev/" $LURE_PATH
 rsync -avL "$LANDSCAPE_REPO/desk-dev/lib/docket.hoon" "$LURE_PATH/lib"
@@ -33,7 +36,7 @@ rm -rf $SOURCE_REPO
 rm -rf $URBIT_REPO
 rm -rf $LANDSCAPE_REPO
 '
-echo "$CMDS" >> $CMD_FILE
+echo "$CMDS" >> "$CMD_FILE"
 
 gcloud compute ssh \
   --internal-ip \
@@ -43,4 +46,4 @@ gcloud compute ssh \
   --command "$(sed '/^$/d' $CMD_FILE | sed ':a;N;s/\n/ && /;$!ba')" \
   $GCP_USER@$SHIP
 
-echo "%lure OTA performed for $SHIP"
+echo "%lure deploy performed for $SHIP"

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SHIP=$1
+BRANCH=$2
+
+CMD_FILE=`mktemp --tmpdir "lure.XXXXXX"`
+CMDS='
+LURE_PATH="'$SHIP'/lure"
+
+SOURCE_REPO=`mktemp -d -t`
+URBIT_REPO=`mktemp -d -t`
+LANDSCAPE_REPO=`mktemp -d -t`
+
+git clone --depth=1 --branch '$BRANCH' https://github.com/tloncorp/lure.git $SOURCE_REPO
+git clone --depth=1 --branch master https://github.com/urbit/urbit.git $URBIT_REPO
+git clone --depth=1 --branch master https://github.com/tloncorp/landscape.git $LANDSCAPE_REPO
+
+curl -s --data '"'"'{"source":{"dojo":"+hood/mount %lure"},"sink":{"app":"hood"}}'"'"' http://localhost:12321 > /dev/null
+
+rsync -avL --delete "$SOURCE_REPO/desk/" $LURE_PATH
+rsync -avL "$URBIT_REPO/pkg/base-dev/" $LURE_PATH
+rsync -avL "$LANDSCAPE_REPO/desk-dev/lib/docket.hoon" "$LURE_PATH/lib"
+rsync -avL "$LANDSCAPE_REPO/desk-dev/sur/docket.hoon" "$LURE_PATH/sur"
+rsync -avL "$LANDSCAPE_REPO/desk-dev/mar/docket-0.hoon" "$LURE_PATH/mar"
+
+curl -s --data '"'"'{"source":{"dojo":"+hood/commit %lure"},"sink":{"app":"hood"}}'"'"' http://localhost:12321 > /dev/null
+curl -s --data '"'"'{"source":{"dojo":"+hood/unmount %lure"},"sink":{"app":"hood"}}'"'"' http://localhost:12321 > /dev/null
+
+rm -rf $SOURCE_REPO
+rm -rf $URBIT_REPO
+rm -rf $LANDSCAPE_REPO
+'
+echo "$CMDS" >> $CMD_FILE
+
+gcloud compute ssh \
+  --internal-ip \
+  --project $GCP_PROJECT \
+  --zone $GCP_ZONE \
+  --ssh-flag="-T" \
+  --command "$(sed '/^$/d' $CMD_FILE | sed ':a;N;s/\n/ && /;$!ba')" \
+  $GCP_USER@$SHIP
+
+echo "%lure OTA performed for $SHIP"

--- a/.github/scripts/glob.sh
+++ b/.github/scripts/glob.sh
@@ -9,7 +9,6 @@ BRANCH=$3
 DIR=$4
 URL=$5
 
-# XX: Do we need '--ignore-existing' opts for dev rsyncs?
 CMD_FILE=`mktemp --tmpdir "lure.XXXXXX"`
 CMDS='
 COOKIE_JAR=`mktemp --tmpdir "lure-cookie.XXXXXX"`

--- a/.github/scripts/glob.sh
+++ b/.github/scripts/glob.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SHIP=$1
+PASSWORD=$2
+BRANCH=$3
+DIR=$4
+URL=$5
+
+# XX: Do we need '--ignore-existing' opts for dev rsyncs?
+CMD_FILE=`mktemp --tmpdir "lure.XXXXXX"`
+CMDS='
+COOKIE_JAR=`mktemp --tmpdir "lure-cookie.XXXXXX"`
+CURL_CMD=`mktemp --tmpdir "lure-upload.XXXXXX"`
+ISOLATION=`mktemp -d -t`
+SOURCE_REPO=`mktemp -d -t`
+
+git clone --depth=1 --branch '$BRANCH' https://github.com/tloncorp/lure.git $SOURCE_REPO
+
+mv '$DIR' $ISOLATION
+cd $ISOLATION
+
+curl --cookie-jar $COOKIE_JAR --data-raw "password='$PASSWORD'" https://'$URL'/~/login
+
+echo "curl --cookie $COOKIE_JAR" >> $CURL_CMD
+echo "--form \"desk=lure\"" >> $CURL_CMD
+find ./ -type f | sed "s:^\./\(.*\)$:--form \"glob=@\1;filename=\1\":g" | sed "s:\.js\"$:.js;type=text/javascript\":g" | sed "s:\.css\"$:.css;type=text/css\":g" >> $CURL_CMD
+echo "https://'$URL'/docket/upload" >> $CURL_CMD
+eval `cat $CURL_CMD | tr "\n" " "`
+
+cd $HOME
+
+rm -rf $SOURCE_REPO
+rm -rf $ISOLATION
+rm -rf $CURL_CMD
+rm -rf $COOKIE_JAR
+'
+echo "$CMDS" >> "$CMD_FILE"
+
+gcloud compute ssh \
+  --internal-ip \
+  --project $GCP_PROJECT \
+  --zone $GCP_ZONE \
+  --ssh-flag="-T" \
+  --command "$(sed '/^$/d' $CMD_FILE | sed ':a;N;s/\n/ && /;$!ba')" \
+  $GCP_USER@$SHIP
+
+echo "%lure glob deployed to $SHIP"

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -12,5 +12,4 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       ship: 'samnec-dozzod-marzod'
-      branch: 'develop'
     secrets: inherit

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,17 +1,18 @@
-name: Push to develop
+name: Deploy Hoon / Development
 
 on:
   push:
     branches:
       - develop
     paths:
+      - '.github/scripts/**.sh'
       - '.github/workflows/**.yml'
-      - '.github/workflows/scripts/**.sh'
       - 'desk/**'
 
 jobs:
   urbit:
-    uses: ./.github/workflows/shared.yml
+    uses: ./.github/workflows/deploy.yml
     with:
       ship: 'samnec-dozzod-marzod'
+      branch: 'develop'
     secrets: inherit

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -12,7 +12,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       ship: 'samnec-dozzod-marzod'
-      password: 'SHIP_PASSWORD_DEV'
       branch: 'develop'
-      url: 'bait-dev.tlon.io'
     secrets: inherit

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -12,5 +12,4 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       ship: 'litnec-dozzod-marzod'
-      branch: 'master'
     secrets: inherit

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -1,17 +1,18 @@
-name: Push to master
+name: Deploy Hoon / Production
 
 on:
   push:
     branches:
       - master
     paths:
+      - '.github/scripts/**.sh'
       - '.github/workflows/**.yml'
-      - '.github/workflows/scripts/**.sh'
       - 'desk/**'
 
 jobs:
   urbit:
-    uses: ./.github/workflows/shared.yml
+    uses: ./.github/workflows/deploy.yml
     with:
       ship: 'litnec-dozzod-marzod'
+      branch: 'master'
     secrets: inherit

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -12,7 +12,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       ship: 'litnec-dozzod-marzod'
-      password: 'SHIP_PASSWORD_PROD'
       branch: 'master'
-      url: 'bait.tlon.io'
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,18 +6,8 @@ on:
         type: string
         default: false
         required: true
-      password:
-        description: 'Password for ship'
-        type: string
-        default: false
-        required: true
       branch:
         description: 'Branch to deploy'
-        type: string
-        default: false
-        required: true
-      url:
-        description: 'Ship DNS'
         type: string
         default: false
         required: true
@@ -30,15 +20,8 @@ on:
         required: true
       GCP_ZONE:
         required: true
-      SHIP_PASSWORD_DEV:
-        required: true
-      SHIP_PASSWORD_PROD:
-        required: true
       TAILSCALE_AUTHKEY:
         required: true
-
-env:
-  FRONTEND_DIR: lure-frontend
 
 jobs:
   upload:
@@ -63,32 +46,6 @@ jobs:
       - id: 'deploy'
         name: 'SSH and sync desk'
         run: ./.github/scripts/deploy.sh ${{ inputs.ship }} ${{ inputs.branch }}
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
-          GCP_ZONE: ${{ secrets.GCP_ZONE }}
-          GCP_USER: ${{ secrets.GCP_USER }}
-
-      - id: 'node-setup'
-        name: 'Setup Node.js'
-        uses: actions/setup-node@v3
-        with:
-          node-version: 19.6
-
-      - id: 'node-depends'
-        name: 'Install Node dependencies'
-        run: cd ui && npm install
-
-      - id: 'node-build'
-        name: 'Build frontend'
-        run: cd ui && npm run build
-
-      - id: 'upload'
-        name: 'Upload frontend to ship'
-        run: gcloud compute scp --internal-ip --project="${{ secrets.GCP_PROJECT }}" --zone="${{ secrets.GCP_ZONE }}" --recurse ./ui/dist ${{ secrets.GCP_USER }}@${{ inputs.SHIP }}:~/$FRONTEND_DIR
-
-      - id: 'glob'
-        name: 'SSH and glob frontend'
-        run: ./.github/scripts/glob.sh ${{ inputs.ship }} ${{ secrets[inputs.password] }} ${{ inputs.branch }} $FRONTEND_DIR ${{ inputs.url }}
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
           GCP_ZONE: ${{ secrets.GCP_ZONE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,6 @@ on:
         type: string
         default: false
         required: true
-      branch:
-        description: 'Branch to deploy'
-        type: string
-        default: false
-        required: true
     secrets:
       GCP_CREDENTIALS:
         required: true
@@ -45,7 +40,7 @@ jobs:
 
       - id: 'deploy'
         name: 'SSH and sync desk'
-        run: ./.github/scripts/deploy.sh ${{ inputs.ship }} ${{ inputs.branch }}
+        run: ./.github/scripts/deploy.sh ${{ inputs.ship }} ${{ github.ref_name }}
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
           GCP_ZONE: ${{ secrets.GCP_ZONE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
         type: string
         default: false
         required: true
+      branch:
+        description: 'Branch to deploy'
+        type: string
+        default: false
+        required: true
     secrets:
       GCP_CREDENTIALS:
         required: true
@@ -21,7 +26,7 @@ on:
 jobs:
   upload:
     runs-on: 'ubuntu-latest'
-    name: 'Sync files to ship'
+    name: 'Deploy Hoon files to ship'
 
     steps:
       - uses: 'actions/checkout@v3'
@@ -38,6 +43,10 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
-      - name: 'SSH and sync'
-        run: |
-          gcloud compute ssh --internal-ip --project ${{ secrets.GCP_PROJECT }} --zone ${{ secrets.GCP_ZONE }} --command './commands/sync.sh' ${{ secrets.GCP_USER }}@${{ inputs.ship }}
+      - id: 'deploy'
+        name: 'SSH and sync'
+        run: ./.github/scripts/deploy.sh ${{ inputs.ship }} ${{ inputs.branch }}
+        env:
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+          GCP_ZONE: ${{ secrets.GCP_ZONE }}
+          GCP_USER: ${{ secrets.GCP_USER }}

--- a/.github/workflows/glob-develop.yml
+++ b/.github/workflows/glob-develop.yml
@@ -1,15 +1,15 @@
-name: Deploy Hoon / Development
+name: Upload Glob / Development
 
 on:
   push:
     branches:
       - develop
     paths:
-      - 'desk/**'
+      - 'ui/**'
 
 jobs:
   urbit:
-    uses: ./.github/workflows/deploy.yml
+    uses: ./.github/workflows/glob.yml
     with:
       ship: 'samnec-dozzod-marzod'
       password: 'SHIP_PASSWORD_DEV'

--- a/.github/workflows/glob-develop.yml
+++ b/.github/workflows/glob-develop.yml
@@ -13,6 +13,5 @@ jobs:
     with:
       ship: 'samnec-dozzod-marzod'
       password: 'SHIP_PASSWORD_DEV'
-      branch: 'develop'
       url: 'bait-dev.tlon.io'
     secrets: inherit

--- a/.github/workflows/glob-master.yml
+++ b/.github/workflows/glob-master.yml
@@ -13,6 +13,5 @@ jobs:
     with:
       ship: 'litnec-dozzod-marzod'
       password: 'SHIP_PASSWORD_PROD'
-      branch: 'master'
       url: 'bait.tlon.io'
     secrets: inherit

--- a/.github/workflows/glob-master.yml
+++ b/.github/workflows/glob-master.yml
@@ -1,15 +1,15 @@
-name: Deploy Hoon / Production
+name: Upload Glob / Production
 
 on:
   push:
     branches:
       - master
     paths:
-      - 'desk/**'
+      - 'ui/**'
 
 jobs:
   urbit:
-    uses: ./.github/workflows/deploy.yml
+    uses: ./.github/workflows/glob.yml
     with:
       ship: 'litnec-dozzod-marzod'
       password: 'SHIP_PASSWORD_PROD'

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -11,11 +11,6 @@ on:
         type: string
         default: false
         required: true
-      branch:
-        description: 'Branch to deploy'
-        type: string
-        default: false
-        required: true
       url:
         description: 'Ship DNS'
         type: string
@@ -80,7 +75,7 @@ jobs:
 
       - id: 'glob'
         name: 'SSH and glob frontend'
-        run: ./.github/scripts/glob.sh ${{ inputs.ship }} ${{ secrets[inputs.password] }} ${{ inputs.branch }} $FRONTEND_DIR ${{ inputs.url }}
+        run: ./.github/scripts/glob.sh ${{ inputs.ship }} ${{ secrets[inputs.password] }} ${{ github.ref_name }} $FRONTEND_DIR ${{ inputs.url }}
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
           GCP_ZONE: ${{ secrets.GCP_ZONE }}

--- a/.github/workflows/glob.yml
+++ b/.github/workflows/glob.yml
@@ -60,14 +60,6 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
-      - id: 'deploy'
-        name: 'SSH and sync desk'
-        run: ./.github/scripts/deploy.sh ${{ inputs.ship }} ${{ inputs.branch }}
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
-          GCP_ZONE: ${{ secrets.GCP_ZONE }}
-          GCP_USER: ${{ secrets.GCP_USER }}
-
       - id: 'node-setup'
         name: 'Setup Node.js'
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -17,10 +17,3 @@ Dev Moon: ~samnec-dozzod-marzod, 34.171.101.183 [Samnec Monitoring](https://cons
 Prod Moon: ~litnec-dozzod-marzod, 35.238.247.180 [Litnec Monitoring](https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/litnec-dozzod-marzod?project=mainnet-tlon-other-2d&pageState=(%22duration%22:(%22groupValue%22:%22PT1H%22,%22customValue%22:null))&tab=monitoring)
 
 http://bait-dev.tlon.io/lure/~sampel-palnet/mytoken
-
-Globbing
-- in lure/ui, run npm run build
-- go to bait-dev.tlon.io/docket/upload
-- upload lure/ui/dist
-- |pass [%e %connect [~ /] %docket]
-- :bait &bind-slash ~


### PR DESCRIPTION
Resolves #34.

I don't know whether it's that `tloncorp/landscape` accesses machines in a different project, or that it uses `IAP`, or that it doesn't use Tailscale, but I cannot for the life of me get the same deployment commands that [work there](https://github.com/tloncorp/landscape/blob/master/.github/helpers/deploy.sh) to work here. Google Cloud Platform just *refuses* to perform input redirection. What you see here is the closest analogue that I could get to work.

Other issues which have shaped these commits:
- No way to do conditional workflow dependencies
  - "If changes to these files on this branch occur, AND workflow A either didn't run or succeeded, THEN run workflow B"
- No way to override secrets
- CURL cannot accurately determine the MIME type of some of the files used for testing because it searches for the *first* `.xxx` match as the file type, instead of the *trailing* `.xxx` match as the file type

**Current status:** Workflows working correctly