### PR TITLE
Lure settings visibility & outstanding pokes bugfixes

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -65,10 +65,10 @@
 ++  on-agent
   |=  [=wire =sign:agent:gall]
   ^-  (quip card _this)
-  ?:  ?=([%ask @ ~] wire)
+  ?:  ?=([%group-enabled @ @ ~] wire)
     ?+  -.sign  (on-agent:def wire sign)
         %poke-ack
-      `this(outstanding-pokes (~(del in outstanding-pokes) [src.bowl i.t.wire]))
+      `this(outstanding-pokes (~(del in outstanding-pokes) [src.bowl i.t.t.wire]))
     ==
   ?-  -.sign
       %poke-ack   `this

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -104,9 +104,10 @@
 ++  on-agent
   |=  [=wire =sign:agent:gall]
   ^-  (quip card _this)
-  ?:  ?=([%token-link-want @ ~] wire)
+  ?:  ?=([%token-link @ @ ~] wire)
     ?+  -.sign  (on-agent:def wire sign)
-        %poke-ack   `this(outstanding-pokes (~(del in outstanding-pokes) [src.bowl i.t.wire]))
+        %poke-ack
+      `this(outstanding-pokes (~(del in outstanding-pokes) [src.bowl i.t.t.wire]))
     ==
   (on-agent:def wire sign)
 ::

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -86,6 +86,10 @@
     =+  !<([token=cord =metadata:reel] vase)
     :_  this(our-metadata (~(put by our-metadata) token metadata))
     ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([token metadata])]]
+      %reel-undescribe
+    =+  !<(token=cord vase)
+    :_  this(our-metadata (~(del by our-metadata) token))
+    ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(token)]]
       %reel-want-token-link
     =+  !<(token=cord vase)
     :_  this

--- a/desk/mar/reel/undescribe.hoon
+++ b/desk/mar/reel/undescribe.hoon
@@ -1,0 +1,14 @@
+/-  reel
+/+  *reel
+|_  token=cord
+++  grad  %noun
+++  grab
+  |%
+  ++  noun  (pair cord cord)
+  ++  json  (ot:dejs:format ~[token+so:dejs:format])
+  --
+++  grow
+  |%
+  ++  noun  token
+  --
+--

--- a/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
+++ b/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
@@ -13,7 +13,7 @@ import {
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { Status } from '@/logic/status';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import { useGroupName } from '@/state/groups/groups';
+import { useGroupName, useGroupShip } from '@/state/groups/groups';
 import {
   useLureBait,
   lureEnableGroup,
@@ -49,6 +49,8 @@ export default function GroupInfoEditor({ title }: ViewProps) {
   const [deleteStatus, setDeleteStatus] = useState<Status>('initial');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const name = useGroupName();
+  const groupShip = useGroupShip();
+  const [lureBait] = useLureBait();
   const [lureEnabled, setLureEnabled] = useLureEnabled(groupFlag);
   const [lureURL, checkLureURL] = useGroupInviteUrl(groupFlag);
   const [copyButtonLabel, setCopyButtonLabel] = useState('Copy');
@@ -173,7 +175,13 @@ export default function GroupInfoEditor({ title }: ViewProps) {
           </footer>
         </form>
       </FormProvider>
-      <div className="card mb-4">
+      <div
+        className={`card mb-4 ${
+          lureBait === '' || groupShip !== `~${window.ship}`
+            ? 'hidden'
+            : 'visible'
+        }`}
+      >
         <div className="flex flex-row">
           <label
             className={

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -840,6 +840,17 @@ export function useGroupName() {
   }, [name]);
 }
 
+export function useGroupShip() {
+  const { ship } = useParams();
+  return useMemo(() => {
+    if (!ship) {
+      return '';
+    }
+
+    return ship;
+  }, [ship]);
+}
+
 /**
  * Alias for useRouteGroup
  * @returns group flag - a string

--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -1,7 +1,7 @@
 import api from '@/api';
 import { useState, useEffect } from 'react';
 import { useEffectOnce } from 'usehooks-ts';
-import { useGroupFlag } from '../groups';
+import { useGroupFlag, useGroupName } from '../groups';
 
 export function useLureBait() {
   const [lureBait, setLureBait] = useState('');
@@ -17,9 +17,31 @@ export function useLureBait() {
   return lureBait;
 }
 
+export async function lurePokeDescribe(token: string, metadata: any) {
+  await api.poke({
+    app: 'reel',
+    mark: 'reel-describe',
+    json: {
+      token,
+      metadata,
+    },
+  });
+}
+
+export async function lurePokeUndescribe(token: string) {
+  await api.poke({
+    app: 'reel',
+    mark: 'reel-undescribe',
+    json: {
+      token,
+    },
+  });
+}
+
 export function useLureEnabled(flag: string): [boolean, (b: boolean) => void] {
   const [lureEnabled, setLureEnabled] = useState<boolean>(false);
   const currentFlag = useGroupFlag();
+  const name = useGroupName();
 
   useEffect(() => {
     if (flag === currentFlag) {
@@ -29,7 +51,13 @@ export function useLureEnabled(flag: string): [boolean, (b: boolean) => void] {
     }
   }, [flag, currentFlag]);
 
-  return [lureEnabled, setLureEnabled];
+  function enableOrDisable(b: boolean) {
+    if (!b) {
+      lurePokeUndescribe(name);
+    }
+    setLureEnabled(b);
+  }
+  return [lureEnabled, enableOrDisable];
 }
 
 export function useLureMetadataExists(
@@ -84,17 +112,6 @@ export function useGroupInviteUrl(flag: string): [string, () => void] {
   useEffect(checkInviteUrl, [flag, currentFlag]);
 
   return [url, checkInviteUrl];
-}
-
-export async function lurePokeDescribe(token: string, metadata: any) {
-  await api.poke({
-    app: 'reel',
-    mark: 'reel-describe',
-    json: {
-      token,
-      metadata,
-    },
-  });
 }
 
 export async function lureEnableGroup(name: string) {

--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -27,7 +27,7 @@ export function useLureEnabled(flag: string): [boolean, (b: boolean) => void] {
         .subscribeOnce('grouper', `/group-enabled/${flag}`, 20000)
         .then((result) => setLureEnabled(result));
     }
-  }, [currentFlag]);
+  }, [flag, currentFlag]);
 
   return [lureEnabled, setLureEnabled];
 }
@@ -81,7 +81,7 @@ export function useGroupInviteUrl(flag: string): [string, () => void] {
     }
   }
 
-  useEffect(checkInviteUrl, [currentFlag]);
+  useEffect(checkInviteUrl, [flag, currentFlag]);
 
   return [url, checkInviteUrl];
 }


### PR DESCRIPTION
Fixes #47 

Lure settings are now only visible to hosts.

Also fixes incorrect expected wires for `outstanding-pokes` acks.

Also removes remote metadata when you disable lure for a group (so that the invite link no longer works).